### PR TITLE
Dd agent 12.3.5172

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 
-FROM datadog/docker-dd-agent
+FROM datadog/docker-dd-agent:12.3.5172
 RUN rm /etc/dd-agent/datadog.conf
 ADD datadog.conf /etc/dd-agent/datadog.conf

--- a/datadog.conf
+++ b/datadog.conf
@@ -30,6 +30,9 @@ api_key:
 # Set the host's tags (optional)
 # tags: mytag, env:prod, role:database
 
+# Collect docker orchestrator name and version as agent tags
+# collect_orchestrator_tags: yes
+
 # Set timeout in seconds for outgoing requests to Datadog. (default: 20)
 # When a request timeout, it will be retried after some time.
 # It will only be deleted if the forwarder queue becomes too big. (30 MB by default)
@@ -122,6 +125,11 @@ histogram_percentiles: 0.99, 0.95
 # sd_backend_host: 127.0.0.1
 # sd_backend_port: 4001
 #
+# If you use etcd, you can set a username and password for auth
+#
+# sd_backend_username:
+# sd_backend_password:
+#
 # By default, the agent will look for the configuration templates under the
 # `/datadog/check_configs` key in the back-end. If you wish otherwise, uncomment this option
 # and modify its value.
@@ -177,6 +185,13 @@ histogram_percentiles: 0.99, 0.95
 # However, it comes with a performance overhead of ~10% in the dogstatsd
 # server. This will be taken care of properly in the new gen agent core.
 # utf8_decoding: false
+
+# The number of bytes allocated to the statsd socket receive buffer. By default,
+# this value is set to the value of `/proc/sys/net/core/rmem_default`. If you
+# need to increase the size of this buffer but keep the OS default value the
+# same, you can set dogstats's receive buffer size here. The maximum allowed
+# value is the value of `/proc/sys/net/core/rmem_max`.
+# statsd_so_rcvbuf:
 
 # ========================================================================== #
 # Service-specific configuration                                             #
@@ -254,3 +269,30 @@ histogram_percentiles: 0.99, 0.95
 log_to_syslog: no
 # syslog_host:
 # syslog_port:
+
+
+# ========================================================================== #
+# Tracing
+# ========================================================================== #
+
+[trace.sampler]
+# Extra global sample rate to apply on all the traces
+# This sample rate is combined to the sample rate from the sampler logic, still promoting interesting traces
+# From 1 (no extra rate) to 0 (don't sample at all)
+extra_sample_rate=1
+
+# Maximum number of traces per second to sample.
+# The limit is applied over an average over a few minutes ; much bigger spikes are possible.
+# Set to 0 to disable the limit.
+max_traces_per_second=10
+
+[trace.receiver]
+# the port that the Receiver should listen on
+receiver_port=8126
+# how many unique client connections to allow during one 30 second lease period
+connection_limit=2000
+
+[trace.ignore]
+# a blacklist of regular expressions can be provided to disable certain traces based on their resource name
+# all entries must be surrounded by double quotes and separated by comas
+resource="GET|POST /healthcheck","GET /V1"


### PR DESCRIPTION
updated datadog.conf to the latest version and pinned to docker-dd-agent:12.3.5172. will remove this version pin so that it always pulls from latest